### PR TITLE
Correcting a bug in recursive Sparql star implementation

### DIFF
--- a/rdflib/plugins/sparql/evaluate.py
+++ b/rdflib/plugins/sparql/evaluate.py
@@ -137,6 +137,8 @@ def _convert_embedded_triple(t):
         v3 = Variable('__' + t[2].toPython())  #Replacing object by a variable if Embedded Triple
         return t[0], t[1], v3
 
+    return t
+
 # Embedded Triple Pattern
 def reifyEmbTP(ctx, reif, triples):
     from rdflib import RDF


### PR DESCRIPTION
Hi @JervenBolleman . There was a missing return statement in the previous implementation. In case there are no embedded triples, the triple object won't be returned making it a null object. Kindly review it. 