### PR TITLE
RDF* support

### DIFF
--- a/examples/rdf_star.py
+++ b/examples/rdf_star.py
@@ -1,0 +1,111 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+# For graphs with multiple rdf reification/* statements
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+            foaf:age 23 .
+    _:s rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:age ;
+    rdf:object 23 .
+
+    _:s dct:creator <http://example.com/crawlers#c1> ;
+        dct:source <http://example.net/listing.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" ;
+                ex:influencedBy ex:welles .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:kubrick ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ex:welles .
+
+    _:s1 dct:creator <http://example.com/names#examples> ;
+        dct:source <http://example.net/people.html> .
+
+    """
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?src WHERE {
+    {?x foaf:age ?age .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:age ;
+    rdf:object ?age ;
+    dct:source ?src . }
+    UNION {
+    ?x ex:influencedBy ?y .
+    ?r2 rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ?y ;
+    dct:source ?src .}
+    }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" .
+    <<ex:bob foaf:age 23>> dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/listing.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" .
+    <<ex:kubrick ex:influencedBy ex:welles>> dct:creator <http://example.com/names#examples> ;
+    dct:source <http://example.net/people.html> .
+
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?age ?src WHERE {
+    { <<?x foaf:age ?age>> dct:source ?src . }
+    UNION
+    { <<?x ex:influencedBy ?y>> dct:source ?src . }
+    }
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph, format="turtle")
+
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    for row in g.query(sparql_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    test_rdf_basic()
+    test_rdf_star()

--- a/examples/rdf_star2.py
+++ b/examples/rdf_star2.py
@@ -1,0 +1,114 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+# For graphs with multiple rdf reification/* statements
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+            foaf:age 23 .
+    _:s rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:age ;
+    rdf:object 23 .
+
+    _:s2 rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:name ;
+    rdf:object "Bob" .
+
+    _:s2 foaf:relatedTo _:s .
+
+    _:s dct:creator <http://example.com/crawlers#c1> ;
+        dct:source <http://example.net/listing.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" ;
+                ex:influencedBy ex:welles .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:kubrick ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ex:welles .
+
+    _:s1 dct:creator <http://example.com/names#examples> ;
+        dct:source <http://example.net/people.html> .
+
+    """
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?y ?name ?age WHERE {
+    ?x foaf:age ?age .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:age ;
+    rdf:object ?age ;
+    dct:source ?src . 
+
+    ?y foaf:name ?name .
+    ?r2 rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:name ;
+    rdf:object ?name .
+    }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    <<ex:bob foaf:age 23>> foaf:relatedTo <<ex:bob foaf:name "Bob">> ;
+    dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/listing.html> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" .
+    <<ex:kubrick ex:influencedBy ex:welles>> dct:creator <http://example.com/names#examples> ;
+    dct:source <http://example.net/people.html> .
+
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?y ?name ?age WHERE 
+    { <<?x foaf:age ?age>> foaf:relatedTo <<?y foaf:name ?name>> .}
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph, format="turtle")
+
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    for row in g.query(sparql_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    test_rdf_basic()
+    test_rdf_star()

--- a/examples/rdf_star_object.py
+++ b/examples/rdf_star_object.py
@@ -1,0 +1,114 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+# For graphs with re-ification as the object rather than subject
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+            foaf:age 23 .
+    _:s rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:age ;
+    rdf:object 23 .
+
+    ex:PeopleInfo dct:isSourceOf _:s ;
+        ex:hasURL <http://example.com/crawlers#c1> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" ;
+                ex:influencedBy ex:welles .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:kubrick ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ex:welles .
+
+    _:s1 dct:creator <http://example.com/names#examples> ;
+        dct:source <http://example.net/people.html> .
+
+    """
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?src WHERE {
+    {?x foaf:age ?age .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:age ;
+    rdf:object ?age .
+    ex:PeopleInfo dct:isSourceOf ?r ;
+    ex:hasURL ?src .}
+    UNION {
+    ?x ex:influencedBy ?y .
+    ?r2 rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate ex:influencedBy ;
+    rdf:object ?y ;
+    dct:source ?src .}
+    }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" .
+    ex:PeopleInfo dct:isSourceOf <<ex:bob foaf:age 23>> ;
+        ex:hasURL <http://example.com/crawlers#c1> .
+
+    ex:welles foaf:name "John Welles" ;
+                ex:mentioned ex:kubrick .
+    ex:kubrick foaf:name "Stanley Kubrick" .
+    <<ex:kubrick ex:influencedBy ex:welles>> dct:creator <http://example.com/names#examples> ;
+    dct:source <http://example.net/people.html> .
+
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?age ?src WHERE {
+    {
+    ex:PeopleInfo dct:isSourceOf <<?x foaf:age ?age>> ;
+    ex:hasURL ?src . }
+    UNION
+    { <<?x ex:influencedBy ?y>> dct:source ?src . }
+    }
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph, format="turtle")
+
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    for row in g.query(sparql_star_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    # test_rdf_basic()
+    test_rdf_star()

--- a/examples/rdf_star_recursive.py
+++ b/examples/rdf_star_recursive.py
@@ -11,14 +11,21 @@ rdf_graph = """
     PREFIX dct:<http://purl.org/dc/terms/>
 
     ex:bob foaf:name "Bob" ;
-            foaf:age 23 .
+            foaf:knows _:s2 .
     _:s rdf:type rdf:Statement ;
     rdf:subject ex:bob ;
-    rdf:predicate foaf:age ;
-    rdf:object 23 .
+    rdf:predicate foaf:knows ;
+    rdf:object _:s2 .
+
+    _:s2 rdf:type rdf:Statement ;
+    rdf:subject ex:alice ;
+    rdf:predicate foaf:name ;
+    rdf:object "Alice" .
 
     _:s dct:creator <http://example.com/crawlers#c1> ;
-        dct:source <http://example.net/listing.html> .
+        dct:source <http://example.net/bob.html> .
+
+    _:s2 dct:source <http://example.net/alice.html> .
 
     ex:welles foaf:name "John Welles" ;
                 ex:mentioned ex:kubrick .
@@ -40,20 +47,19 @@ sparql_query = """
     PREFIX foaf:<http://xmlns.com/foaf/0.1/>
     PREFIX dct:<http://purl.org/dc/terms/>
 
-    SELECT ?x ?src WHERE {
-    {?x foaf:age ?age .
+    SELECT ?x ?y ?srcX ?srcY WHERE {
+    ?x foaf:knows ?r2 .
     ?r rdf:type rdf:Statement ;
     rdf:subject ?x ;
-    rdf:predicate foaf:age ;
-    rdf:object ?age ;
-    dct:source ?src . }
-    UNION {
-    ?x ex:influencedBy ?y .
+    rdf:predicate foaf:knows ;
+    rdf:object ?r2 ;
+    dct:source ?srcX . 
+
     ?r2 rdf:type rdf:Statement ;
-    rdf:subject ?x ;
-    rdf:predicate ex:influencedBy ;
-    rdf:object ?y ;
-    dct:source ?src .}
+    rdf:subject ?y ;
+    rdf:predicate foaf:name ;
+    rdf:object ?name ;
+    dct:source ?srcY
     }
 """
 
@@ -64,8 +70,10 @@ rdf_Star_graph = """
     PREFIX dct:<http://purl.org/dc/terms/>
 
     ex:bob foaf:name "Bob" .
-    <<ex:bob foaf:age 23>> dct:creator <http://example.com/crawlers#c1> ;
-    dct:source <http://example.net/listing.html> .
+    <<ex:bob foaf:knows <<ex:alice foaf:name "Alice">>>> dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/bob.html> .
+
+    <<ex:alice foaf:name "Alice">> dct:source <http://example.net/alice.html> .
 
     ex:welles foaf:name "John Welles" ;
                 ex:mentioned ex:kubrick .
@@ -81,11 +89,9 @@ sparql_star_query = """
     PREFIX foaf:<http://xmlns.com/foaf/0.1/>
     PREFIX dct:<http://purl.org/dc/terms/>
 
-    SELECT ?x ?age ?src WHERE {
-    { <<?x foaf:age ?age>> dct:source ?src . }
-    UNION
-    { <<?x ex:influencedBy ?y>> dct:source ?src . }
-    }
+    SELECT ?x ?y ?srcX ?srcY WHERE 
+    { <<ex:bob foaf:knows <<?y foaf:name ?name>>>> dct:source ?srcX . 
+    <<?y foaf:name ?name>> dct:source ?srcY .}
 
 """
 
@@ -102,10 +108,10 @@ def test_rdf_star():
     g = Graph()
     g.parse(data=rdf_Star_graph, format="turtle")
 
-    for row in g.query(sparql_star_query):
+    for row in g.query(sparql_query):
         print(row)
 
 
 if __name__ == '__main__':
-    test_rdf_basic()
+    # test_rdf_basic()
     test_rdf_star()

--- a/examples/rdf_star_simple.py
+++ b/examples/rdf_star_simple.py
@@ -84,10 +84,10 @@ def test_rdf_star():
     g = Graph()
     g.parse(data=rdf_Star_graph, format="turtle")
 
-    for row in g.query(sparql_query):
+    for row in g.query(sparql_star_query):
         print(row)
 
 
 if __name__ == '__main__':
-    #test_rdf_basic()
+    test_rdf_basic()
     test_rdf_star()

--- a/examples/rdf_star_simple.py
+++ b/examples/rdf_star_simple.py
@@ -1,0 +1,93 @@
+from rdflib import Graph
+from rdflib.namespace import RDF, Namespace
+from pyparsing import ParseException
+
+rdf_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" ;
+    foaf:age 23 .
+    _:s1 rdf:type rdf:Statement ;
+    rdf:subject ex:bob ;
+    rdf:predicate foaf:age ;
+    rdf:object 23 .
+
+    _:s1 dct:creator <http://example.com/crawlers#c1> ;
+        dct:source <http://example.net/listing.html> .
+
+    """
+
+rdf_graph2 = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" .
+    _:s dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/listing.html> .
+
+ex:bob foaf:age 23 .
+_:s rdf:type rdf:Statement ; rdf:subject ex:bob ; rdf:predicate foaf:age ; rdf:object 23 .
+
+"""
+
+sparql_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?age ?src WHERE {
+    ?x foaf:age ?age .
+    ?r rdf:type rdf:Statement ;
+    rdf:subject ?x ;
+    rdf:predicate foaf:age ;
+    rdf:object ?age ;
+    dct:source ?src . }
+"""
+
+rdf_Star_graph = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    ex:bob foaf:name "Bob" .
+    <<ex:bob foaf:age 23>> dct:creator <http://example.com/crawlers#c1> ;
+    dct:source <http://example.net/listing.html> .
+"""
+
+sparql_star_query = """
+    PREFIX ex:<http://example.org/>
+    PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX foaf:<http://xmlns.com/foaf/0.1/>
+    PREFIX dct:<http://purl.org/dc/terms/>
+
+    SELECT ?x ?age ?src WHERE { <<?x foaf:age ?age>> dct:source ?src . }
+
+"""
+
+
+def test_rdf_basic():
+    g = Graph()
+    g.parse(data=rdf_graph2, format="turtle")
+
+    for row in g.query(sparql_query):
+        print(row)
+
+
+def test_rdf_star():
+    g = Graph()
+    g.parse(data=rdf_Star_graph, format="turtle")
+
+    for row in g.query(sparql_query):
+        print(row)
+
+
+if __name__ == '__main__':
+    #test_rdf_basic()
+    test_rdf_star()

--- a/rdflib/plugins/parsers/notation3.py
+++ b/rdflib/plugins/parsers/notation3.py
@@ -349,7 +349,9 @@ ws = re.compile(r'[ \t]*')                       # Whitespace not including NL
 signed_integer = re.compile(r'[-+]?[0-9]+')      # integer
 integer_syntax = re.compile(r'[-+]?[0-9]+')
 decimal_syntax = re.compile(r'[-+]?[0-9]*\.[0-9]+')
-exponent_syntax = re.compile(r'[-+]?(?:[0-9]+\.[0-9]*|\.[0-9]+|[0-9]+)(?:e|E)[-+]?[0-9]+')
+exponent_syntax = re.compile(r'[-+]?(?:[0-9]+\.[0-9]*(?:e|E)[-+]?[0-9]+|'+
+                             r'\.[0-9](?:e|E)[-+]?[0-9]+|'+
+                             r'[0-9]+(?:e|E)[-+]?[0-9]+)')
 digitstring = re.compile(r'[0-9]+')              # Unsigned integer
 interesting = re.compile(r"""[\\\r\n\"\']""")
 langcode = re.compile(r'[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*')
@@ -362,6 +364,7 @@ class SinkParser:
         the  # will get added during qname processing """
 
         self._bindings = {}
+        self.bNodeCounter = 0
         if thisDoc != "":
             assert ':' in thisDoc, "Document URI not absolute: <%s>" % thisDoc
             self._bindings[""] = thisDoc + "#"   # default
@@ -471,7 +474,10 @@ class SinkParser:
             if j < 0:
                 return
 
-            i = self.directiveOrStatement(s, j)
+            result = self.directiveOrStatement(s, j)
+            #print ("I was returned",result)
+            s = result[0]
+            i = result[1]
             if i < 0:
                 #print("# next char: %s" % s[j])
                 self.BadSyntax(s, j,
@@ -481,22 +487,27 @@ class SinkParser:
 
         i = self.skipSpace(argstr, h)
         if i < 0:
-            return i    # EOF
+            return argstr, i    # EOF
 
         if self.turtle:
-            j = self.sparqlDirective(argstr, i)
+            j = self.sparqlDirective(argstr, i) # TO EVALUATE DIRECTIVE STATEMENTS: Binds the prefix to namespaces and takes care of BASE
             if j >= 0:
-                return j
+                return argstr, j
 
-        j = self.directive(argstr, i)
+        j = self.directive(argstr, i) #Check for other Directive statements (BIND, FORALL, FORSOME, other keyqords)
         if j >= 0:
-            return self.checkDot(argstr, j)
+            return argstr, self.checkDot(argstr, j)
+
+        #Check if the format is rdf* or not
+        #If it is then change the string to include reification
+        argstr = self.changeStarToReification(argstr, i)
 
         j = self.statement(argstr, i)
+        #print ("I got this ",j)
         if j >= 0:
-            return self.checkDot(argstr, j)
+            return argstr, self.checkDot(argstr, j)
 
-        return j
+        return argstr, j
 
      # @@I18N
      # _namechars = string.lowercase + string.uppercase + string.digits + '_-'
@@ -650,7 +661,7 @@ class SinkParser:
         j = self.sparqlTok('PREFIX', argstr, i)
         if j >= 0:
             t = []
-            i = self.qname(argstr, j, t)
+            i = self.qname(argstr, j, t)    #To check this prefix is in keywird(namespaces) and URI is correct
             if i < 0:
                 self.BadSyntax(argstr, j,
                     "expected qname after @prefix")
@@ -667,7 +678,7 @@ class SinkParser:
                     "With no base URI, cannot use " +
                     "relative URI in @prefix <" + ns + ">")
             assert ':' in ns  # must be absolute
-            self._bindings[t[0][0]] = ns
+            self._bindings[t[0][0]] = ns    #Create Bindings for this namespace (bind the prefix to URI)
             self.bind(t[0][0], hexify(ns))
             return j
 
@@ -722,6 +733,63 @@ class SinkParser:
          # $$$$$$$$$$$$$$$$$$$$$
          # print "# Parser output: ", `quadruple`
         self._store.makeStatement(quadruple, why=self._reason2)
+
+    def getEmbeddedTuple(self, argstr, i):
+        i = i+2
+        j=i
+        while(argstr[j+1:j+3]!=">>"):
+            j = j+1
+
+        substr = argstr[i:j+1] + " ."
+        return i,j,substr
+
+    def changeStarToReification(self, argstr, i):
+        # Check if the Star statement is present anywhere in the given statement
+        # Find the position and extract this embedded tuple
+        # The star statement could also be present as a subject or an object, check for that
+        if ("<<" in argstr and ">>" in argstr):
+            while (i <= len(argstr)):
+                if (argstr[i:i + 2] == "<<"):  # We have found rdf* syntax with reification of subject
+                    # Converting into rdf reification statement
+                    posStart, posEnd, substr = self.getEmbeddedTuple(argstr, i)  # Retrieve the Embedded Triple
+
+                    # Replace this embeddedTriple with a empty node
+                    # assign a number to this node for multiple re-ifications possible
+                    self.bNodeCounter += 1
+                    argstr = argstr[:posStart-2] + "_:s"+str(self.bNodeCounter) +argstr[posEnd+3:]
+                    #argstr = argstr[:posStart - 2] + "_:s" + argstr[posEnd + 3:]
+
+                    # Add the reification triples
+                    argstr = argstr + "\n" + substr + "\n"
+                    # Get the Subject, predicate and Object of the embedded triple
+                    ptr = 0
+                    Er = []
+                    ptr = self.object(substr, 0, Er)
+                    # Esub = Er[0]
+                    Esub = substr[:ptr]
+                    print(Esub)
+
+                    Ev = []
+                    ptr2 = self.verb(substr, ptr, Ev)
+                    Epred = substr[ptr + 1:ptr2]
+                    # Edir, Epred = Ev[0]
+                    print(Epred)
+
+                    objs = []
+                    ptr3 = self.objectList(substr, ptr2, objs)
+                    # Eobj = objs[0]
+                    Eobj = substr[ptr2 + 1:ptr3 - 1]
+                    print(Eobj)
+
+                    argstr = argstr + "_:s"+str(self.bNodeCounter)+" rdf:type rdf:Statement ; rdf:subject "+str(Esub)+" ; rdf:predicate "+str(Epred)+" ; rdf:object "+str(Eobj)+" .\n"
+                    #argstr = argstr + "_:s rdf:type rdf:Statement ; rdf:subject " + str(Esub) + " ; rdf:predicate " + str(Epred) + " ; rdf:object " + str(Eobj) + " .\n"
+                    print("Reified graph is as follows: ")
+                    print(argstr)
+
+                else:
+                    i = i + 1
+
+        return argstr
 
     def statement(self, argstr, i):
         r = []
@@ -1871,7 +1939,7 @@ class TurtleParser(Parser):
         pass
 
     def parse(self, source, graph, encoding="utf-8", turtle=True):
-
+        """set up SinkParser and bindings of prefixes and namespaces"""
         if encoding not in [None, "utf-8"]:
             raise Exception(
                 ("N3/Turtle files are always utf-8 encoded, ",


### PR DESCRIPTION
Support added for parsing RDF* graphs. 
Additional code in parser for Turtle, i.e. notation3.py to change any embedded triples to reification statements. 
Tested for graphs with multiple embedded statements and examples to test for RDF* embedded triples as subject, object, both subject and object and recursively embedded triples.